### PR TITLE
Add a dummy reference to a non-existent mask file

### DIFF
--- a/l_cysteine_narrow_wedge/11_integrated.expt
+++ b/l_cysteine_narrow_wedge/11_integrated.expt
@@ -17,7 +17,7 @@
     {
       "__id__": "ImageSequence",
       "template": "l-cyst_01_#####.cbf",
-      "mask": "",
+      "mask": "non-existent.pickle",
       "gain": "",
       "pedestal": "",
       "dx": "",

--- a/l_cysteine_narrow_wedge/README.md
+++ b/l_cysteine_narrow_wedge/README.md
@@ -2,3 +2,7 @@ Integrated data derived from two 1° wedges, each of ten 0.1° images.
 These data were generated with xia2 and DIALS (May 2020, master) from the first ten images of each of the first two sweeps of the DIALS small molecule tutorial data set, `l_cyst_01` and `l_cyst_02` [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.51405.svg)](https://doi.org/10.5281/zenodo.51405).
  * `11_integrated.{expt,refl}` — the integrated data from the first ten `l_cyst_01` images.
  * `23_integrated.{expt,refl}` — the integrated data from the first ten `l_cyst_02` images.
+
+In addition:
+ * The `11_integrated.expt` experiment list file has had its hot pixel mask file reference (the entry `["imageset"][0]["mask"]`) set to a non-existent file path `non-existent.pickle`, to allow for testing of missing file references.
+ * The `23_integrated.expt` experiment list file has had its corresponding hot pixel mask file reference removed, i.e. the entry has been set to an empty string.


### PR DESCRIPTION
In order to test that DXTBX experiment list creation is robust to broken pickle file references, such as missing imageset hot pixel masks, it would be useful to include such a broken reference in an experiment list.  Preferably, this should be an experiment list that contains a valid image template reference when fetched in a Pytest test with the `dials_data` fixture.  That way, we can test this simply by calling `dxtbx.model.ExperimentList(filename, check_format=True)`.

`l_cysteine_narrow_wedge/11_integrated.expt` matches this description.  It is listed in
https://github.com/dials/data/blob/master/dials_data/definitions/l_cysteine_dials_output.yml
so `dials_data` already downloads it to a directory that contains an image file to match the `template`.  Here I introduce a deliberately broken dummy file reference
`"mask": "non-existent.pickle"`.

This PR should be accompanied by another in https://github.com/dials/data.