### PR TITLE
update insulin_processed image paths

### DIFF
--- a/insulin_processed/imported.expt
+++ b/insulin_processed/imported.expt
@@ -14,7 +14,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",

--- a/insulin_processed/indexed.expt
+++ b/insulin_processed/indexed.expt
@@ -15,7 +15,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",

--- a/insulin_processed/integrated.expt
+++ b/insulin_processed/integrated.expt
@@ -16,7 +16,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",

--- a/insulin_processed/refined.expt
+++ b/insulin_processed/refined.expt
@@ -15,7 +15,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",

--- a/insulin_processed/scaled.expt
+++ b/insulin_processed/scaled.expt
@@ -17,7 +17,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",

--- a/insulin_processed/symmetrized.expt
+++ b/insulin_processed/symmetrized.expt
@@ -16,7 +16,7 @@
   "imageset": [
     {
       "__id__": "ImageSequence",
-      "template": "insulin_1_###.img",
+      "template": "../insulin/insulin_1_###.img",
       "mask": "",
       "gain": "",
       "pedestal": "",


### PR DESCRIPTION
This just updates the image paths of `insulin_processed/*.expt` to match the locations in dials_data. This would allow functions like  `ExperimentListFactory.from_json_file(dials_data("insulin_processed", pathlib=True)/"refined.expt")`, which check the image files exist, to run without error (described in [issue #372](https://github.com/dials/data/issues/372)).